### PR TITLE
refactor: use standard Frappe pattern for is_standard validation

### DIFF
--- a/tweaks/hooks.py
+++ b/tweaks/hooks.py
@@ -17,6 +17,7 @@ after_install = [
     "tweaks.custom.doctype.user_group.apply_user_group_patches",
     "tweaks.custom.doctype.role.apply_role_patches",
     "tweaks.tweaks.doctype.ac_rule.ac_rule_utils.after_install",
+    "tweaks.utils.sync_job_type.sync_job_types",
 ]
 
 after_migrate = [

--- a/tweaks/tweaks/doctype/sync_job_type/sync_job_type.py
+++ b/tweaks/tweaks/doctype/sync_job_type/sync_job_type.py
@@ -41,9 +41,17 @@ class SyncJobType(Document):
             self.is_standard = "No"
             if (
                 frappe.session.user == "Administrator"
-                and getattr(frappe.local.conf, "developer_mode", 0) == 1
+                and frappe.conf.developer_mode
             ):
                 self.is_standard = "Yes"
+
+        # Standard Sync Job Types cannot be modified in production
+        if self.is_standard == "Yes" and not frappe.conf.developer_mode:
+            frappe.throw(
+                _(
+                    "Standard Sync Job Type cannot be modified. Enable Developer Mode to edit."
+                )
+            )
 
         if self.is_standard == "No":
             # Allow only script manager to edit
@@ -55,13 +63,6 @@ class SyncJobType(Document):
                         "Cannot edit a standard sync job type. Please duplicate and create a new one"
                     )
                 )
-
-        if self.is_standard == "Yes" and frappe.session.user != "Administrator":
-            frappe.throw(
-                _(
-                    "Only Administrator can save a standard sync job type. Please rename and save."
-                )
-            )
 
         # Soft validate sync job module if exists
         if self.is_standard == "Yes":


### PR DESCRIPTION
## What

Replaces custom `is_standard` validation checks on `Sync Job Type` with the standard Frappe pattern used by Report, DocType, Print Format, and Workflow.

## Changes

### `sync_job_type.py`
- `getattr(frappe.local.conf, "developer_mode", 0) == 1` → `frappe.conf.developer_mode`
- `frappe.session.user != "Administrator"` → `not frappe.conf.developer_mode`
- Error message updated to match Frappe convention: *"Standard Sync Job Type cannot be modified. Enable Developer Mode to edit."*

### `hooks.py`
- Added `sync_job_types` to `after_install` hook — standard Sync Job Types now sync on app install, not just on migrate

## Pattern reference

Frappe's standard pattern across Report, DocType, Print Format, Workflow:
```python
if self.is_standard == "Yes" and not frappe.conf.developer_mode:
    frappe.throw(_("Standard X cannot be modified"))
```

This is simpler and more consistent than checking `frappe.session.user` or `frappe.flags.in_*`.